### PR TITLE
(temporarily) allow failing of lts-2 due to issue with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ matrix:
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
   - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack ARGS="--resolver lts-2 --stack-yaml stack-7.8.4.yaml"
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it


### PR DESCRIPTION
Due to [this](https://github.com/travis-ci/travis-ci/issues/6522) issue the OSX build for lts-2 fails. Thus I decided to add lts-2 to the list of allowed failure.